### PR TITLE
party affiliation

### DIFF
--- a/src/js/components/pages.js
+++ b/src/js/components/pages.js
@@ -2,6 +2,7 @@ import { LinkBlock } from "./link-block.js";
 import { FullWidthGrid } from "./grid.js";
 import { ExpandableRichText } from "./rich-text";
 import { PageTitle, SectionHeading } from "./headings.js";
+import { PartyAffiliationBlock } from "./party-affiliation.js";
 import { Breadcrumbs } from "./breadcrumbs.js";
 import { Contact } from "./contact.js";
 
@@ -40,17 +41,21 @@ class Page {
     });
     this.breadcrumbItems = breadcrumbsWithLabel;
     this.childPages = content.child_pages;
+    this.politicalParty = content.political_party;
     this.profileImage = content.profile_image;
     this.contacts = this.initContacts(content);
   }
 
-  initContacts(content) { return []; };
+  initContacts(content) {
+    return [];
+  }
 
   render() {
     return [
       new PageTitle(this.name).render(),
       new Breadcrumbs(this.breadcrumbItems).render(),
       ...this.renderProfileImage(),
+      ...this.renderPartyAffiliation(),
       ...this.renderOverview(),
       ...this.renderContacts(),
       ...this.renderChildPageLinks(),
@@ -62,7 +67,22 @@ class Page {
     if (this.profileImage) {
       const imageUrl = this.profileImage.meta.download_url;
       const imageAlt = this.profileImage.title;
-      elements.push($(`<img src="${imageUrl}" alt="imageAlt"></a>`));
+      elements.push($(`<img src="${imageUrl}" alt="${imageAlt}"></img>`));
+    }
+    return elements;
+  }
+
+  renderPartyAffiliation() {
+    const elements = [];
+
+    if (this.politicalParty) {
+      elements.push(
+        new PartyAffiliationBlock({
+          partyLogo: this.politicalParty.logo_image_tumbnail,
+          partyName: this.politicalParty.name,
+          partyAbbr: this.politicalParty.abbreviation,
+        }).render()
+      );
     }
     return elements;
   }
@@ -100,7 +120,9 @@ class Page {
     });
     if (childPageLinks.length) {
       return [new FullWidthGrid(childPageLinks).render()];
-    } else { return []; }
+    } else {
+      return [];
+    }
   }
 }
 
@@ -114,9 +136,7 @@ export class CouncillorListPage extends Page {}
 
 export class PersonPage extends Page {
   initContacts(content) {
-    return content.person_contacts.map(
-      (details) => new Contact(details)
-    );
+    return content.person_contacts.map((details) => new Contact(details));
   }
 }
 

--- a/src/js/components/party-affiliation.js
+++ b/src/js/components/party-affiliation.js
@@ -1,0 +1,45 @@
+export class PartyAffiliationBlock {
+  constructor(props) {
+    this.element = $(`
+        <style>
+            .party-affiliation {
+                align-items: center;
+                display: flex;
+                margin-top: 12px;
+                padding: 12px;
+            }
+
+            h4 {
+                margin: 0;
+            }
+
+            .text-content {
+                flex-basis: 80%;
+            }
+
+            .img-container {
+                flex-basis: 20%;
+                text-align: right;
+            }
+
+            .img-container img {
+                height: auto;
+                width: 28px;
+            }
+        </style>
+        <div class="party-affiliation card">
+            <div class="text-content">
+                <h3 class="h3-block-title">Party Affiliation</h3>
+                <h4 class="subtitle">${props.partyName} (${props.partyAbbr})</h4>
+            </div>
+            <div class="img-container">
+                <img src="${props.partyLogo.url}" width="${props.partyLogo.width}" height="${props.partyLogo.height}" alt="${props.partyLogo.alt}" />
+            </div>
+        </div>
+    `);
+  }
+
+  render() {
+    return this.element;
+  }
+}


### PR DESCRIPTION
Add party affiliation component to Person pages.

We do not seem to have a template in the HTML for this component already so, I kinda made one using the poor man's `jsx` 😸  Let me know if this works for you and if so, we can merge like this and then have the appropriate person move this into the HTML and CSS via Webflow.

![Screenshot 2020-10-23 at 06 47 21](https://user-images.githubusercontent.com/10350960/96957695-9c815300-14fb-11eb-8575-86f73100f374.png)

Also, let me know if there are privacy concerns when adding screen shots like this in a PR.

fix #26