### PR TITLE
councillor thumbnails

### DIFF
--- a/src/css/citizen-engagement-app.webflow.css
+++ b/src/css/citizen-engagement-app.webflow.css
@@ -296,6 +296,11 @@ strong {
   flex: 1;
 }
 
+.styles.hidden {
+  display: none;
+  width: auto;
+}
+
 .search-block {
   position: relative;
   display: -webkit-box;
@@ -1086,8 +1091,11 @@ strong {
 }
 
 .link-block__image {
-  width: 56px;
+  width: auto;
+  height: 100%;
   max-width: none;
+  -o-object-fit: fill;
+  object-fit: fill;
 }
 
 .div-block {

--- a/src/index.html
+++ b/src/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!--  This site was created in Webflow. http://www.webflow.com  --><!--  Last Published: Wed Nov 04 2020 10:10:02 GMT+0000 (Coordinated Universal Time)  --><html data-wf-page="5f586c03cfc82e5a3c067594" data-wf-site="5f586c03cfc82e2e15067593"><head>
+<!DOCTYPE html><!--  This site was created in Webflow. http://www.webflow.com  --><!--  Last Published: Fri Nov 06 2020 15:06:59 GMT+0000 (Coordinated Universal Time)  --><html data-wf-page="5f586c03cfc82e5a3c067594" data-wf-site="5f586c03cfc82e2e15067593"><head>
   <meta charset="utf-8">
   <title>Citizen Engagement App</title>
   <meta content="width=device-width, initial-scale=1" name="viewport">

--- a/src/js/components/link-block.js
+++ b/src/js/components/link-block.js
@@ -21,11 +21,21 @@ export class LinkBlock {
       this.targetIconContainer.attr("class", "");
       this.targetIconContainer.addClass(props.targetIconClasses);
     }
-    // if subtitle is set to an empty string, return an empty string
+
     if (props.subtitle || props.subtitle === "") {
       this.subtitleContainer = this.element.find(".subtitle");
       console.assert(this.subtitleContainer.length == 1);
       this.subtitleContainer.text(props.subtitle);
+    }
+
+    if (props.profileImageThumbnail) {
+      this.$profileImageThumbnailImg = this.element.find("img");
+      this.$profileImageThumbnailImg.attr({
+        src: props.profileImageThumbnail.url,
+        alt: props.profileImageThumbnail.alt,
+        height: props.profileImageThumbnail.height,
+        width: props.profileImageThumbnail.width,
+      });
     }
   }
 
@@ -39,19 +49,29 @@ export class LinkBlock {
     ) {
       return $(".styles .link-block:eq(5)");
     }
+
     if (props.targetIconClasses && props.subjectIconClasses && props.subtitle) {
       return $(".styles .link-block:eq(6)");
     }
+
     if (props.subjectIconClasses && (props.subtitle || props.subtitle === "")) {
       return $(".styles .link-block:eq(6)");
     }
+
+    // https://app.gitbook.com/@openup/s/cape-agulhas-app/design-system/link-block#container-classes-7
+    if (props.subtitle && props.profileImageThumbnail) {
+      return $(".styles .link-block:eq(8)");
+    }
+
     // https://app.gitbook.com/@openup/s/cape-agulhas-app/design-system/link-block#container-classes-3
     if (props.subtitle || props.subtitle === "") {
       return $(".styles .link-block:eq(4)");
     }
+
     if (props.subjectIconClasses) {
       return $(".styles .link-block:eq(3)");
     }
+
     return $(".styles .link-block:eq(2)");
   }
 

--- a/src/js/components/pages.js
+++ b/src/js/components/pages.js
@@ -120,6 +120,15 @@ class Page {
         subtitle: "",
       };
 
+      // councillors have a job title we can pass as the subtitle
+      if (page.job_title) {
+        props.subtitle = page.job_title;
+      }
+
+      if (page.profile_image_thumbnail) {
+        props.profileImageThumbnail = page.profile_image_thumbnail;
+      }
+
       // only pass `subjectIconClasses` if it is specified in the data
       if (page.icon_classes) {
         props.subjectIconClasses = page.icon_classes;
@@ -127,6 +136,7 @@ class Page {
 
       return new LinkBlock(props);
     });
+
     if (childPageLinks.length) {
       return [new FullWidthGrid(childPageLinks).render()];
     } else {

--- a/src/js/components/pages.js
+++ b/src/js/components/pages.js
@@ -171,13 +171,24 @@ export class CouncillorGroupPage extends Page {
 
   renderCouncillorLinks() {
     const memberLinks = this.members.map((page) => {
-      return new LinkBlock({
+      const props = {
         title: page.title,
         subtitle: "",
         url: page.url,
         subjectIconClasses: page.icon_classes,
-      });
+      };
+
+      if (page.job_title) {
+        props.subtitle = page.job_title;
+      }
+
+      if (page.profile_image_thumbnail) {
+        props.profileImageThumbnail = page.profile_image_thumbnail;
+      }
+
+      return new LinkBlock(props);
     });
+
     if (memberLinks.length) {
       return [
         new SectionHeading(this.membersLabel).render(),


### PR DESCRIPTION
Show councillor thumbnails on list page

This is how it is shown at the moment:

![Screenshot 2020-11-06 at 09 22 15](https://user-images.githubusercontent.com/10350960/98337892-fca2e980-2011-11eb-8d8b-8f2cb66d628e.png)

There is the following CSS class:

```
.link-block__image {
    width: 56px;
    max-width: none;
}
```

We should probably change it to:

```
.link-block__image {
    max-width: inherit;
}
```

Then it will display the thumbnails as below:

![Screenshot 2020-11-06 at 09 22 26](https://user-images.githubusercontent.com/10350960/98338056-3aa00d80-2012-11eb-89e9-b2c8fafa45bb.png)

fix #29