### PR TITLE
fix: use thumbnail link block for head of service

### DIFF
--- a/src/js/components/pages.js
+++ b/src/js/components/pages.js
@@ -271,11 +271,18 @@ export class Service {
     this.overview = service.overview;
 
     if (service.head_of_service) {
-      this.headOfService = new LinkBlock({
+      const props = {
         title: service.head_of_service.title,
         subtitle: service.head_of_service.job_title,
         url: service.head_of_service.url,
-      });
+      };
+
+      if (service.head_of_service.profile_image_thumbnail) {
+        props.profileImageThumbnail =
+          service.head_of_service.profile_image_thumbnail;
+      }
+
+      this.headOfService = new LinkBlock(props);
     }
 
     this.servicePoints = service.child_pages.map(


### PR DESCRIPTION
This will now use the link block with an image thumbnail when a thumbnail is available in the data.

## With thumbnail

![Screenshot 2020-11-10 at 13 41 44](https://user-images.githubusercontent.com/10350960/98669980-b07ddf00-235a-11eb-8d64-a483d35b318b.png)

## Without thumbnail

![Screenshot 2020-11-10 at 13 41 52](https://user-images.githubusercontent.com/10350960/98669994-b4116600-235a-11eb-96aa-5bb09acb7ae5.png)
