### PR TITLE
fix: hide gradient on expand

### DIFF
--- a/src/js/components/rich-text.js
+++ b/src/js/components/rich-text.js
@@ -1,35 +1,35 @@
 export class ExpandableRichText {
   constructor(html) {
-    this.template = $(".styles .expandable-rich-text");
-    this.element = this.template.clone();
-    this.contentContainer = this.element.find(".rich-text");
-    this.gradientContainer = this.element.find(".rich-text__gradient");
-    this.openButton = this.element.find(".expand-toggle__content-first");
-    this.closeButton = this.element.find(".expand-toggle__content-last");
+    this.$template = $(".styles .expandable-rich-text");
+    this.$element = this.$template.clone();
+    this.$contentContainer = this.$element.find(".rich-text");
+    this.$gradientContainer = this.$element.find(".rich-text__gradient");
+    this.$openButton = this.$element.find(".expand-toggle__content-first");
+    this.$closeButton = this.$element.find(".expand-toggle__content-last");
 
     // Interactions
-    this.openButton.on(
+    this.$openButton.on(
       "click",
       (() => {
-        this.contentContainer.addClass("expanded");
-        this.gradientContainer.addClass("expanded");
-        this.openButton.addClass("expanded");
+        this.$contentContainer.addClass("expanded");
+        this.$gradientContainer.addClass("expanded");
+        this.$openButton.addClass("expanded");
       }).bind(this)
     );
-    this.closeButton.on(
+    this.$closeButton.on(
       "click",
       (() => {
-        this.contentContainer.removeClass("expanded");
-        this.gradientContainer.removeClass("expanded");
-        this.openButton.removeClass("expanded");
+        this.$contentContainer.removeClass("expanded");
+        this.$gradientContainer.removeClass("expanded");
+        this.$openButton.removeClass("expanded");
       }).bind(this)
     );
 
     // Content
-    this.contentContainer.html(html);
+    this.$contentContainer.html(html);
   }
 
   render() {
-    return this.element;
+    return this.$element;
   }
 }

--- a/src/js/components/rich-text.js
+++ b/src/js/components/rich-text.js
@@ -1,9 +1,9 @@
 export class ExpandableRichText {
-  template = $(".styles .expandable-rich-text");
-
   constructor(html) {
+    this.template = $(".styles .expandable-rich-text");
     this.element = this.template.clone();
     this.contentContainer = this.element.find(".rich-text");
+    this.gradientContainer = this.element.find(".rich-text__gradient");
     this.openButton = this.element.find(".expand-toggle__content-first");
     this.closeButton = this.element.find(".expand-toggle__content-last");
 
@@ -12,6 +12,7 @@ export class ExpandableRichText {
       "click",
       (() => {
         this.contentContainer.addClass("expanded");
+        this.gradientContainer.addClass("expanded");
         this.openButton.addClass("expanded");
       }).bind(this)
     );
@@ -19,6 +20,7 @@ export class ExpandableRichText {
       "click",
       (() => {
         this.contentContainer.removeClass("expanded");
+        this.gradientContainer.removeClass("expanded");
         this.openButton.removeClass("expanded");
       }).bind(this)
     );


### PR DESCRIPTION
Add and remove expanded class on `.rich-text__gradient` as component is expanded and collapsed

fix #41