### PR TITLE
fix: login

### DIFF
--- a/src/js/api.js
+++ b/src/js/api.js
@@ -82,6 +82,11 @@ export class API {
     return $.get(url);
   }
 
+  login(endPoint, userDetails) {
+    const url = `${this.baseUrl}${endPoint}`;
+    return $.post({ url, data: userDetails });
+  }
+
   registerUser(endPoint, userDetails) {
     const url = `${this.baseUrl}${endPoint}`;
     return $.post({ url, data: userDetails });

--- a/src/js/components/account/login.js
+++ b/src/js/components/account/login.js
@@ -1,0 +1,86 @@
+import { API } from "../../api";
+import { setMenuState } from "../../utils/menu";
+import {
+  getDiv,
+  getForm,
+  getInput,
+  getLabel,
+  getSubmitButton,
+} from "../../utils/element-factory";
+
+export class Login {
+  constructor() {
+    const $successTemplate = $(".styles .form-styles .w-form-done").clone();
+    const $failTemplate = $(".styles .form-styles .w-form-fail").clone();
+
+    const defaultBaseUrl = "https://muni-portal-backend.openup.org.za";
+    const endPoint = "/api/accounts/login/";
+    const fields = [
+      {
+        label: "login",
+        type: "text",
+      },
+      {
+        label: "password",
+        type: "password",
+      },
+    ];
+    const $loginFormContainer = getDiv("form w-form");
+    const $form = getForm(`${defaultBaseUrl}${endPoint}`, "post");
+    const $submitButton = getSubmitButton("Login");
+
+    fields.forEach((field) => {
+      const $formElementsContainer = $("<div />");
+      $formElementsContainer.append(getLabel(field.label));
+      $formElementsContainer.append(getInput(field.type, field.label));
+      $form.append($formElementsContainer);
+    });
+
+    $form.append($submitButton);
+
+    $loginFormContainer.append($form);
+    $loginFormContainer.append($successTemplate);
+    $loginFormContainer.append($failTemplate);
+
+    $form.submit((event) => {
+      event.preventDefault();
+      this.login(endPoint, $form, $successTemplate, $failTemplate);
+    });
+
+    this.$element = $loginFormContainer;
+  }
+
+  /**
+   * Calls API providing user login details and attempts a login via
+   * the API.
+   * @param {String} endPoint - the API endpoint
+   * @param {jqObject} $form - the form to submit
+   * @param {jqObject} $success - reference to the success template
+   * @param {jqObject} $fail  - reference to the failure template
+   */
+  login(endPoint, $form, $success, $fail) {
+    const api = new API();
+    const response = api.login(endPoint, $form.serialize());
+    response
+      .done((response, textStatus) => {
+        if (textStatus === "success") {
+          localStorage.setItem("user", response.token);
+          $form.hide();
+          $success.empty().append("You are now logged in").show();
+          setMenuState();
+        }
+      })
+      .fail((jqXHR, textStatus) => {
+        $form.hide();
+        $fail
+          .empty()
+          .append("Error while communicating with the server")
+          .show();
+        console.error(jqXHR, textStatus);
+      });
+  }
+
+  render() {
+    return this.$element;
+  }
+}

--- a/src/js/components/account/login.js
+++ b/src/js/components/account/login.js
@@ -65,9 +65,12 @@ export class Login {
       .done((response, textStatus) => {
         if (textStatus === "success") {
           localStorage.setItem("user", response.token);
+          setMenuState();
+
           $form.hide();
           $success.empty().append("You are now logged in").show();
-          setMenuState();
+
+          window.location = "/services/";
         }
       })
       .fail((jqXHR, textStatus) => {

--- a/src/js/components/account/user-registration-verify.js
+++ b/src/js/components/account/user-registration-verify.js
@@ -1,4 +1,4 @@
-import { API } from "../api";
+import { API } from "../../api";
 
 export class VerifyUserRegistration {
   constructor() {

--- a/src/js/components/account/user-registration.js
+++ b/src/js/components/account/user-registration.js
@@ -1,11 +1,11 @@
-import { API } from "../api";
+import { API } from "../../api";
 import {
   getDiv,
   getForm,
   getInput,
   getLabel,
   getSubmitButton,
-} from "../utils/element-factory";
+} from "../../utils/element-factory";
 
 export class UserRegistration {
   constructor() {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -21,9 +21,12 @@ import {
 import * as pages from "./components/pages.js";
 import { API } from "./api.js";
 
+import { setMenuState, updateMenuLinks } from "./utils/menu";
+
+import { Login } from "./components/account/login";
 import { ForgotPassword } from "./components/account/forgot-password";
-import { UserRegistration } from "./components/user-registration";
-import { VerifyUserRegistration } from "./components/user-registration-verify";
+import { UserRegistration } from "./components/account/user-registration";
+import { VerifyUserRegistration } from "./components/account/user-registration-verify";
 
 // Call as early as possible to maximise chance of registering reinstallation code
 tryRegisterSW();
@@ -81,9 +84,9 @@ class App {
     // HACK TO HIDE DEFAULT ADDED FIRST TAB
     $mainContainer.find(".tab-link__wrap").first().remove();
 
-    // HACK: Set registration link on create account link
-    const createAccountLink = $(".nav-menu__links a:nth-child(2)");
-    createAccountLink.attr("href", "/accounts/register/");
+    updateMenuLinks();
+    // sets the menu state based on the users login state
+    setMenuState();
 
     this.modalPage = new ModalPage($(".main .page__wrap"));
 
@@ -108,6 +111,11 @@ class App {
         path: new RegExp("^/my-municipality/administration/$"),
         view: this.viewAdministrationIndex.bind(this),
         viewType: "Administration landing",
+      },
+      {
+        path: new RegExp("^/accounts/login/$"),
+        view: this.viewLogin.bind(this),
+        viewType: "Authentication",
       },
       {
         path: new RegExp("^/accounts/register/$"),
@@ -244,6 +252,13 @@ class App {
       .fail(function (a, b) {
         console.error(a, b);
       });
+  }
+
+  viewLogin() {
+    this.modalPage.show();
+    const login = new Login();
+    this.setTitle("Sign in to MyMuni");
+    this.modalPage.setContent(login.render());
   }
 
   viewUserRegistration() {

--- a/src/js/utils/element-factory.js
+++ b/src/js/utils/element-factory.js
@@ -1,5 +1,3 @@
-import { getHubFromCarrier } from "@sentry/browser";
-
 export const getDiv = (className) => {
   return $("<div />", {
     class: className,
@@ -20,7 +18,7 @@ export const getInput = (type, label) => {
     class: "card input-field w-input",
     type: type,
     name: name,
-    id: `registration-${label}`,
+    id: `my-muni-${label}`,
   });
 };
 

--- a/src/js/utils/menu.js
+++ b/src/js/utils/menu.js
@@ -1,0 +1,57 @@
+/**
+ * Adds an event listener to the logout button and logs out the
+ * current user by clearing the `user` entry in `localStorage`
+ * @param {jqObject} $logoutButton - the logout button element
+ */
+function handleLogout($logoutButton) {
+  $logoutButton.on("click", () => {
+    localStorage.removeItem("user");
+    setMenuState();
+  });
+}
+
+/**
+ * This is a temporary measure until the links are updated in Webflow
+ */
+export const updateMenuLinks = () => {
+  const singinLink = $(".nav-menu__links a:nth-child(1)");
+  singinLink.attr("href", "/accounts/login/");
+
+  const createAccountLink = $(".nav-menu__links a:nth-child(2)");
+  createAccountLink.attr("href", "/accounts/register/");
+};
+
+export const setMenuState = () => {
+  const $navMenu = $(".nav-menu__links");
+  const $signinLink = $(".nav-menu__links a:nth-child(1)");
+  const $registerLink = $(".nav-menu__links a:nth-child(2)");
+
+  let $logoutButton = $("#my-muni-logout");
+
+  if (localStorage.getItem("user")) {
+    if ($logoutButton.length === 0) {
+      $logoutButton = $("<button />", {
+        class: "nav-link w-inline-block w--current",
+        id: "my-muni-logout",
+        type: "button",
+        text: "Logout",
+      });
+      $navMenu.append($logoutButton);
+    } else {
+      $logoutButton.show();
+    }
+
+    $signinLink.hide();
+    $registerLink.hide();
+
+    handleLogout($logoutButton);
+  } else {
+    if (!$logoutButton) {
+      return;
+    }
+
+    $logoutButton.hide();
+    $signinLink.show();
+    $registerLink.show();
+  }
+};

--- a/src/js/utils/menu.js
+++ b/src/js/utils/menu.js
@@ -7,6 +7,7 @@ function handleLogout($logoutButton) {
   $logoutButton.on("click", () => {
     localStorage.removeItem("user");
     setMenuState();
+    window.location = "/services/";
   });
 }
 


### PR DESCRIPTION
Allow a user to log in and logout

As mentioned on Slack, I am simply clearing the token from `localStorage` as I am not sure whether there is a need to actually call the back-end. If we do need to, then I believe the docs needs to be updated to indicate how credentials are to be passed.

I reckon I still need to redirect the user to `/services/` once successfully logged out and in so, will update the PR soon with that as well.

fix #61