### PR TITLE
fix: close modal

### DIFF
--- a/src/js/components/molecules/modal-header.js
+++ b/src/js/components/molecules/modal-header.js
@@ -7,14 +7,14 @@
 export const getModalHeader = (title, $element) => {
   const $modalHeader = $(".styles .page-heading--icon-left").clone();
   // the above consists of three elements
-  // 1. A icon aligned to the left
-  const $spinner = $modalHeader.find(".page__icon");
+  // 1. An icon aligned to the left
+  const $icon = $modalHeader.find(".page__icon");
   // 2. A page title
   const $modalTitle = $modalHeader.find(".page-title");
   // 3. A close icon
   const $modalClose = $modalHeader.find(".page-close__icon");
 
-  $spinner.hide();
+  $icon.hide();
   $modalTitle.text(title);
 
   if ($modalClose) {

--- a/src/js/components/molecules/modal-header.js
+++ b/src/js/components/molecules/modal-header.js
@@ -21,17 +21,7 @@ export const getModalHeader = (title, $element) => {
     $modalClose.click((event) => {
       // as this is currently an anchor, preventDefault
       event.preventDefault();
-      // if there are 2 or less items in history it
-      // might very well be that the two entries are
-      // 1. new tab page
-      // 2. the current page
-      // so, let's just go to the landing page
-      if (history.length <= 2) {
-        window.location = "/";
-      } else {
-        // go back to the previous URL
-        history.back();
-      }
+      window.location = "/";
     });
   }
 

--- a/src/js/components/molecules/modal-header.js
+++ b/src/js/components/molecules/modal-header.js
@@ -21,7 +21,17 @@ export const getModalHeader = (title, $element) => {
     $modalClose.click((event) => {
       // as this is currently an anchor, preventDefault
       event.preventDefault();
-      $element.toggleClass("hidden");
+      // if there are 2 or less items in history it
+      // might very well be that the two entries are
+      // 1. new tab page
+      // 2. the current page
+      // so, let's just go to the landing page
+      if (history.length <= 2) {
+        window.location = "/";
+      } else {
+        // go back to the previous URL
+        history.back();
+      }
     });
   }
 

--- a/src/js/components/molecules/modal-header.js
+++ b/src/js/components/molecules/modal-header.js
@@ -1,0 +1,29 @@
+/**
+ * Returns a modal header with a click event attached to the
+ * close icon that will close the modal.
+ * @param {string} title - title of the modal
+ * @param {jqObject} $element - The modal element
+ */
+export const getModalHeader = (title, $element) => {
+  const $modalHeader = $(".styles .page-heading--icon-left").clone();
+  // the above consists of three elements
+  // 1. A icon aligned to the left
+  const $spinner = $modalHeader.find(".page__icon");
+  // 2. A page title
+  const $modalTitle = $modalHeader.find(".page-title");
+  // 3. A close icon
+  const $modalClose = $modalHeader.find(".page-close__icon");
+
+  $spinner.hide();
+  $modalTitle.text(title);
+
+  if ($modalClose) {
+    $modalClose.click((event) => {
+      // as this is currently an anchor, preventDefault
+      event.preventDefault();
+      $element.toggleClass("hidden");
+    });
+  }
+
+  return $modalHeader;
+};

--- a/src/js/components/notifications/index.js
+++ b/src/js/components/notifications/index.js
@@ -53,7 +53,7 @@ export const NotificationsSettings = () => {
     "input[type='checkbox']"
   );
   const $inAppNotificationsNoSupportMsg = new BasicBlock({
-    title: "In-app notifications is not supported on your device",
+    title: "In-app notifications are not supported on your device",
     subtitle: "",
   });
   // is Notifications and ServiceWorker supported?

--- a/src/js/components/pages.js
+++ b/src/js/components/pages.js
@@ -8,6 +8,8 @@ import { Breadcrumbs } from "./breadcrumbs.js";
 import { Contact } from "./contact.js";
 import { ServicePoint } from "./service-point.js";
 
+import { getModalHeader } from "./molecules/modal-header";
+
 export class ModalPage {
   constructor(element) {
     console.assert(element.length === 1);
@@ -15,8 +17,10 @@ export class ModalPage {
     this.page = element.find(".page-content");
   }
 
-  setContent(content) {
+  setContent(content, title) {
+    const $modalHeader = getModalHeader(title, this.element);
     this.page.empty();
+    this.page.append($modalHeader);
     this.page.append(content);
   }
 
@@ -46,7 +50,7 @@ class Page {
     this.role = content.job_title;
     this.politicalParty = content.political_party;
     this.profileImage = content.profile_image;
-    this.contacts = this.initContacts(content);
+    this.contacts = this.initContacts();
   }
 
   initContacts() {
@@ -55,7 +59,6 @@ class Page {
 
   render() {
     return [
-      new PageTitle(this.name).render(),
       new Breadcrumbs(this.breadcrumbItems).render(),
       ...this.renderProfileImage(),
       ...this.renderOverview(),
@@ -142,7 +145,6 @@ export class CouncillorGroupPage extends Page {
 
   render() {
     return [
-      new PageTitle(this.name).render(),
       new Breadcrumbs(this.breadcrumbItems).render(),
       ...this.renderProfileImage(),
       ...this.renderOverview(),
@@ -188,7 +190,6 @@ export class CouncillorListPage extends Page {}
 export class PersonPage extends Page {
   render() {
     const pageContent = [
-      new PageTitle(this.name).render(),
       new Breadcrumbs(this.breadcrumbItems).render(),
       ...this.renderProfileImage(),
     ];
@@ -218,7 +219,11 @@ export class PersonPage extends Page {
   }
 
   initContacts(content) {
-    return content.person_contacts.map((details) => new Contact(details));
+    if (content && content.person_contacts) {
+      return content.person_contacts.map((details) => new Contact(details));
+    } else {
+      return [];
+    }
   }
 }
 
@@ -298,10 +303,7 @@ export class Service {
   }
 
   render() {
-    const children = [
-      new PageTitle(this.name).render(),
-      new Breadcrumbs(this.breadcrumbItems).render(),
-    ];
+    const children = [new Breadcrumbs(this.breadcrumbItems).render()];
 
     if (this.overview.trim() !== "") {
       children.push(

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -179,8 +179,9 @@ class App {
         ((response) => {
           console.assert(response.meta.total_count == 1);
           const service = new Service(response.items[0]);
-          this.setTitle(response.items[0].title);
-          this.modalPage.setContent(service.render());
+          const title = response.items[0].title;
+          this.setTitle(title);
+          this.modalPage.setContent(service.render(), title);
         }).bind(this)
       )
       .fail(function (a, b) {
@@ -200,8 +201,9 @@ class App {
             if (type in pages) {
               const pageClass = pages[type];
               const page = new pageClass(response);
-              this.setTitle(response.title);
-              this.modalPage.setContent(page.render());
+              const title = response.title;
+              this.setTitle(title);
+              this.modalPage.setContent(page.render(), title);
             } else {
               this.modalPage.setContent(
                 new ErrorPage(
@@ -233,8 +235,9 @@ class App {
           console.assert(response.meta.total_count == 1);
           const content = response.items[0];
           const administrationIndex = new AdministrationIndex(content);
-          this.setTitle(content.title);
-          this.modalPage.setContent(administrationIndex.render());
+          const title = response.title;
+          this.setTitle(title);
+          this.modalPage.setContent(administrationIndex.render(), title);
         }).bind(this)
       )
       .fail(function (a, b) {
@@ -251,8 +254,9 @@ class App {
         ((response) => {
           console.assert(response.meta.total_count == 1);
           const administrator = new Administrator(response.items[0]);
-          this.setTitle(response.items[0].title);
-          this.modalPage.setContent(administrator.render());
+          const title = response.items[0].title;
+          this.setTitle(title);
+          this.modalPage.setContent(administrator.render(), title);
         }).bind(this)
       )
       .fail(function (a, b) {
@@ -263,36 +267,41 @@ class App {
   viewLogin() {
     this.modalPage.show();
     const login = new Login();
-    this.setTitle("Sign in to MyMuni");
-    this.modalPage.setContent(login.render());
+    const title = "Sign in to MyMuni";
+    this.setTitle(title);
+    this.modalPage.setContent(login.render(), title);
   }
 
   viewUserRegistration() {
     this.modalPage.show();
     const userRegistration = new UserRegistration();
-    this.setTitle("Register for MyMuni");
-    this.modalPage.setContent(userRegistration.render());
+    const title = "Register for MyMuni";
+    this.setTitle(title);
+    this.modalPage.setContent(userRegistration.render(), title);
   }
 
   viewForgotPassword() {
     this.modalPage.show();
     const forgotPassword = new ForgotPassword();
-    this.setTitle("Forgot your password?");
-    this.modalPage.setContent(forgotPassword.render());
+    const title = "Forgot Password";
+    this.setTitle(title);
+    this.modalPage.setContent(forgotPassword.render(), title);
   }
 
   viewVerifyUserRegistration() {
     this.modalPage.show();
     const verifyUserRegsistration = new VerifyUserRegistration();
-    this.setTitle("Verify User Registration");
-    this.modalPage.setContent(verifyUserRegsistration.render());
+    const title = "Verify User Registration";
+    this.setTitle(title);
+    this.modalPage.setContent(verifyUserRegsistration.render(), title);
   }
 
   viewAccountSettings() {
     this.modalPage.show();
     const userSettings = new UserSettings();
-    this.setTitle("User settings");
-    this.modalPage.setContent(userSettings.render());
+    const title = "User settings";
+    this.setTitle(title);
+    this.modalPage.setContent(userSettings.render(), title);
   }
 }
 


### PR DESCRIPTION
Enable the first iteration of the close modal functionality.
This also required an update to all modal so that they only pass their title and not set their own page title.

fix #72
