### PR TITLE
fix: add to homescreen

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "start": "yarn build && yarn serve",
     "build": "parcel build ./src/index.html --public-url /",
     "dev": "parcel serve -p 8080 ./src/index.html --public-url /",
+    "dev:https": "parcel serve -p 8080 --https ./src/index.html --public-url /",
     "serve": "http-server -d false -c-1 --proxy http://localhost:8080? dist",
     "serve-https": "http-server -S -C server-cert.pem -K server-cert-key.pem -d false -c-1 --proxy http://localhost:8080? dist",
     "mkcert-loopback": "mkcert -cert-file server-cert.pem -key-file server-cert-key.pem 127.0.0.1"
@@ -44,7 +45,7 @@
   "assetsPath": "./src/service-worker/",
   "cache": {
     "strategy": "inject",
-    "swSrc": "src/service-worker/service-worker.js",
+    "swSrc": "src/service-worker.js",
     "swDest": "service-worker.js",
     "globDirectory": "dist",
     "globPatterns": [

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,0 +1,42 @@
+importScripts(
+  "https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js"
+);
+
+workbox.precaching.precacheAndRoute([]);
+workbox.routing.registerRoute(
+  new RegExp(".+/api/wagtail/v2/pages/.*"),
+  new workbox.strategies.NetworkFirst()
+);
+
+addEventListener("message", (event) => {
+  if (event.data && event.data.type === "SKIP_WAITING") {
+    console.log("Got 'SKIP_WAITING'");
+    skipWaiting();
+  }
+});
+
+let messageURL = "";
+
+self.addEventListener("push", function (event) {
+  const messageData = event.data.json();
+
+  if (messageData.type !== "notification") {
+    return;
+  }
+
+  const title = messageData.notification.title;
+  const options = {
+    body: messageData.notification.body,
+    icon: "./cape-agulhas-logo-square.03316029.png",
+  };
+
+  messageURL = messageData.notification.url;
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  event.waitUntil(clients.openWindow(messageURL));
+});
+
+self.__WB_DISABLE_DEV_LOGS = true;


### PR DESCRIPTION
Moves `service-worker.js` to root off `src` directory. This allows `yarn build` to succeed.
Perhaps this was the root cause?

fix #74
