### PR TITLE
Add password reset 

### DIFF
--- a/src/css/citizen-engagement-app.webflow.css
+++ b/src/css/citizen-engagement-app.webflow.css
@@ -1988,11 +1988,6 @@ strong {
   flex: 0 0 auto;
 }
 
-.link-text.form-submit {
-  display: inline-block;
-  margin-top: 8px;
-}
-
 .nav-menu__links {
   display: -ms-grid;
   display: grid;

--- a/src/css/citizen-engagement-app.webflow.css
+++ b/src/css/citizen-engagement-app.webflow.css
@@ -1988,6 +1988,11 @@ strong {
   flex: 0 0 auto;
 }
 
+.link-text.form-submit {
+  display: inline-block;
+  margin-top: 8px;
+}
+
 .nav-menu__links {
   display: -ms-grid;
   display: grid;

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -171,6 +171,11 @@ export class API {
     return $.post({ url, data: userDetails });
   }
 
+  resetPassword(endPoint, userDetails) {
+    const url = `${this.baseUrl}${endPoint}`;
+    return $.post({ url, data: userDetails });
+  }
+
   verifyUserRegistration(endPoint, userDetails) {
     const url = `${this.baseUrl}${endPoint}`;
     return $.post({ url, data: userDetails });

--- a/src/js/components/account/forgot-password.js
+++ b/src/js/components/account/forgot-password.js
@@ -55,7 +55,8 @@ export class ForgotPassword {
           $success
             .empty()
             .append(
-              "If we found an account with the email address you provided, you should receive a reset link soon."
+              "If we found an account with the email address you provided, " +
+                "you should receive a reset link soon."
             )
             .show();
         }
@@ -65,7 +66,8 @@ export class ForgotPassword {
         $fail
           .empty()
           .append(
-            "Something went wrong while communicating with the server. Please try again or contact support."
+            "Something went wrong while communicating with the server. " +
+              "Please try again or contact support."
           )
           .show();
         console.error(jqXHR, textStatus);

--- a/src/js/components/account/login.js
+++ b/src/js/components/account/login.js
@@ -6,7 +6,7 @@ import {
   getForm,
   getInput,
   getLabel,
-  getSubmitButton
+  getSubmitButton,
 } from "../../utils/element-factory";
 
 export class Login {
@@ -29,7 +29,11 @@ export class Login {
     const $loginFormContainer = getDiv("form w-form");
     const $form = getForm(`${defaultBaseUrl}${endPoint}`, "post");
     const $submitButton = getSubmitButton("Login");
-    const $forgotPasswordLink = getAnchorElement("/accounts/forgot-password/", "link-text form-submit", "I forgot my password")
+    const $forgotPasswordLink = getAnchorElement(
+      "/accounts/forgot-password/",
+      "link-text form-submit",
+      "I forgot my password"
+    );
 
     fields.forEach((field) => {
       const $formElementsContainer = $("<div />");
@@ -43,7 +47,7 @@ export class Login {
     $loginFormContainer.append($form);
     $loginFormContainer.append($successTemplate);
     $loginFormContainer.append($failTemplate);
-    $loginFormContainer.append($forgotPasswordLink)
+    $loginFormContainer.append($forgotPasswordLink);
 
     $form.submit((event) => {
       event.preventDefault();

--- a/src/js/components/account/login.js
+++ b/src/js/components/account/login.js
@@ -1,11 +1,12 @@
 import { API } from "../../api";
 import { setMenuState } from "../../utils/menu";
 import {
+  getAnchorElement,
   getDiv,
   getForm,
   getInput,
   getLabel,
-  getSubmitButton,
+  getSubmitButton
 } from "../../utils/element-factory";
 
 export class Login {
@@ -28,6 +29,7 @@ export class Login {
     const $loginFormContainer = getDiv("form w-form");
     const $form = getForm(`${defaultBaseUrl}${endPoint}`, "post");
     const $submitButton = getSubmitButton("Login");
+    const $forgotPasswordLink = getAnchorElement("/accounts/forgot-password/", "link-text form-submit", "I forgot my password")
 
     fields.forEach((field) => {
       const $formElementsContainer = $("<div />");
@@ -41,6 +43,7 @@ export class Login {
     $loginFormContainer.append($form);
     $loginFormContainer.append($successTemplate);
     $loginFormContainer.append($failTemplate);
+    $loginFormContainer.append($forgotPasswordLink)
 
     $form.submit((event) => {
       event.preventDefault();

--- a/src/js/components/account/reset-password.js
+++ b/src/js/components/account/reset-password.js
@@ -5,15 +5,19 @@ import {
   getForm,
   getInput,
   getLabel,
-  getSubmitButton
+  getSubmitButton,
 } from "../../utils/element-factory";
 
 export class ResetPassword {
   constructor() {
     const $successTemplate = $(".styles .form-styles .w-form-done").clone();
     const $failTemplate = $(".styles .form-styles .w-form-fail").clone();
-    const $loginAnchor = getAnchorElement('/accounts/login/', 'link-text form-submit', 'Please log in with your new password');
-    $loginAnchor.hide()
+    const $loginAnchor = getAnchorElement(
+      "/accounts/login/",
+      "link-text form-submit",
+      "Please log in with your new password"
+    );
+    $loginAnchor.hide();
 
     const defaultBaseUrl = "https://muni-portal-backend.openup.org.za";
     const endPoint = "/api/accounts/reset-password/";
@@ -28,9 +32,9 @@ export class ResetPassword {
 
     // Add security values as hidden inputs and populate from query params
     const urlParams = new URLSearchParams(window.location.search);
-    urlParams.forEach(function(value, key) {
-      $formElementsContainer.append(getInput("hidden", key, value))
-    })
+    urlParams.forEach(function (value, key) {
+      $formElementsContainer.append(getInput("hidden", key, value));
+    });
 
     $form.append($formElementsContainer);
     $form.append($submitButton);
@@ -42,7 +46,13 @@ export class ResetPassword {
 
     $form.submit((event) => {
       event.preventDefault();
-      this.resetPassword(endPoint, $form, $successTemplate, $failTemplate, $loginAnchor);
+      this.resetPassword(
+        endPoint,
+        $form,
+        $successTemplate,
+        $failTemplate,
+        $loginAnchor
+      );
     });
 
     this.$element = $resetFormContainer;
@@ -65,9 +75,7 @@ export class ResetPassword {
           $form.hide();
           $success
             .empty()
-            .append(
-              `Your password was changed successfully.`
-            )
+            .append(`Your password was changed successfully.`)
             .show();
           $loginAnchor.show();
         }

--- a/src/js/components/account/reset-password.js
+++ b/src/js/components/account/reset-password.js
@@ -12,7 +12,6 @@ export class ResetPassword {
     const $successTemplate = $(".styles .form-styles .w-form-done").clone();
     const $failTemplate = $(".styles .form-styles .w-form-fail").clone();
 
-    // TODO: Is this necessary? why not set the default in api.js?
     const defaultBaseUrl = "https://muni-portal-backend.openup.org.za";
     const endPoint = "/api/accounts/reset-password/";
 
@@ -23,6 +22,12 @@ export class ResetPassword {
     const $formElementsContainer = $("<div />");
     $formElementsContainer.append(getLabel("new password"));
     $formElementsContainer.append(getInput("password", "password"));
+
+    // Add security values as hidden inputs and populate from query params
+    const urlParams = new URLSearchParams(window.location.search);
+    urlParams.forEach(function(value, key) {
+      $formElementsContainer.append(getInput("hidden", key, value))
+    })
 
     $form.append($formElementsContainer);
     $form.append($submitButton);

--- a/src/js/components/account/reset-password.js
+++ b/src/js/components/account/reset-password.js
@@ -24,7 +24,7 @@ export class ResetPassword {
 
     const $resetFormContainer = getDiv("form w-form");
     const $form = getForm(`${defaultBaseUrl}${endPoint}`, "post");
-    const $submitButton = getSubmitButton("Set New Password");
+    const $submitButton = getSubmitButton("Update password");
 
     const $formElementsContainer = $("<div />");
     $formElementsContainer.append(getLabel("new password"));

--- a/src/js/components/account/reset-password.js
+++ b/src/js/components/account/reset-password.js
@@ -1,5 +1,6 @@
 import { API } from "../../api";
 import {
+  getAnchorElement,
   getDiv,
   getForm,
   getInput,
@@ -11,6 +12,8 @@ export class ResetPassword {
   constructor() {
     const $successTemplate = $(".styles .form-styles .w-form-done").clone();
     const $failTemplate = $(".styles .form-styles .w-form-fail").clone();
+    const $loginAnchor = getAnchorElement('/accounts/login/', 'link-text form-submit', 'Please log in with your new password');
+    $loginAnchor.hide()
 
     const defaultBaseUrl = "https://muni-portal-backend.openup.org.za";
     const endPoint = "/api/accounts/reset-password/";
@@ -35,10 +38,11 @@ export class ResetPassword {
     $resetFormContainer.append($form);
     $resetFormContainer.append($successTemplate);
     $resetFormContainer.append($failTemplate);
+    $resetFormContainer.append($loginAnchor);
 
     $form.submit((event) => {
       event.preventDefault();
-      this.resetPassword(endPoint, $form, $successTemplate, $failTemplate);
+      this.resetPassword(endPoint, $form, $successTemplate, $failTemplate, $loginAnchor);
     });
 
     this.$element = $resetFormContainer;
@@ -50,8 +54,9 @@ export class ResetPassword {
    * @param {jqObject} $form - the form to submit
    * @param {jqObject} $success - reference to the success template
    * @param {jqObject} $fail  - reference to the failure template
+   * @param {jqObject} $loginAnchor - reference to the login anchor
    */
-  resetPassword(endPoint, $form, $success, $fail) {
+  resetPassword(endPoint, $form, $success, $fail, $loginAnchor) {
     const api = new API();
     const response = api.resetPassword(endPoint, $form.serialize());
     response
@@ -61,9 +66,10 @@ export class ResetPassword {
           $success
             .empty()
             .append(
-              "Your password was changed successfully."
+              `Your password was changed successfully.`
             )
             .show();
+          $loginAnchor.show();
         }
       })
       .fail((jqXHR, textStatus) => {

--- a/src/js/components/account/reset-password.js
+++ b/src/js/components/account/reset-password.js
@@ -1,0 +1,79 @@
+import { API } from "../../api";
+import {
+  getDiv,
+  getForm,
+  getInput,
+  getLabel,
+  getSubmitButton
+} from "../../utils/element-factory";
+
+export class ResetPassword {
+  constructor() {
+    const $successTemplate = $(".styles .form-styles .w-form-done").clone();
+    const $failTemplate = $(".styles .form-styles .w-form-fail").clone();
+
+    // TODO: Is this necessary? why not set the default in api.js?
+    const defaultBaseUrl = "https://muni-portal-backend.openup.org.za";
+    const endPoint = "/api/accounts/reset-password/";
+
+    const $resetFormContainer = getDiv("form w-form");
+    const $form = getForm(`${defaultBaseUrl}${endPoint}`, "post");
+    const $submitButton = getSubmitButton("Set New Password");
+
+    const $formElementsContainer = $("<div />");
+    $formElementsContainer.append(getLabel("new password"));
+    $formElementsContainer.append(getInput("password", "password"));
+
+    $form.append($formElementsContainer);
+    $form.append($submitButton);
+
+    $resetFormContainer.append($form);
+    $resetFormContainer.append($successTemplate);
+    $resetFormContainer.append($failTemplate);
+
+    $form.submit((event) => {
+      event.preventDefault();
+      this.resetPassword(endPoint, $form, $successTemplate, $failTemplate);
+    });
+
+    this.$element = $resetFormContainer;
+  }
+
+  /**
+   * Calls API end point to set a new password for the user
+   * @param {String} endPoint - the API endpoint
+   * @param {jqObject} $form - the form to submit
+   * @param {jqObject} $success - reference to the success template
+   * @param {jqObject} $fail  - reference to the failure template
+   */
+  resetPassword(endPoint, $form, $success, $fail) {
+    const api = new API();
+    const response = api.resetPassword(endPoint, $form.serialize());
+    response
+      .done((response, textStatus) => {
+        if (textStatus === "success") {
+          $form.hide();
+          $success
+            .empty()
+            .append(
+              "Your password was changed successfully."
+            )
+            .show();
+        }
+      })
+      .fail((jqXHR, textStatus) => {
+        $form.hide();
+        $fail
+          .empty()
+          .append(
+            "Something went wrong while communicating with the server. Please try again or contact support."
+          )
+          .show();
+        console.error(jqXHR, textStatus);
+      });
+  }
+
+  render() {
+    return this.$element;
+  }
+}

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -25,6 +25,7 @@ import { setMenuState, updateMenuLinks } from "./utils/menu";
 
 import { Login } from "./components/account/login";
 import { ForgotPassword } from "./components/account/forgot-password";
+import { ResetPassword } from "./components/account/reset-password";
 import { UserRegistration } from "./components/account/user-registration";
 import { UserSettings } from "./components/account/user-settings";
 import { VerifyUserRegistration } from "./components/account/user-registration-verify";

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -129,7 +129,7 @@ class App {
         viewType: "User Registration",
       },
       {
-        path: new RegExp("^/accounts/reset-password/$"),
+        path: new RegExp("^/accounts/forgot-password/$"),
         view: this.viewForgotPassword.bind(this),
         viewType: "User Management",
       },

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -134,6 +134,11 @@ class App {
         viewType: "User Management",
       },
       {
+        path: new RegExp("^/accounts/reset-password/$"),
+        view: this.viewResetPassword.bind(this),
+        viewType: "User Management",
+      },
+      {
         path: new RegExp("^/account/settings/$"),
         view: this.viewAccountSettings.bind(this),
         viewType: "User Settings",
@@ -286,6 +291,14 @@ class App {
     const title = "Forgot Password";
     this.setTitle(title);
     this.modalPage.setContent(forgotPassword.render(), title);
+  }
+
+  viewResetPassword() {
+    this.modalPage.show();
+    const resetPassword = new ResetPassword();
+    const title = "Reset Password";
+    this.setTitle(title);
+    this.modalPage.setContent(resetPassword.render(), title);
   }
 
   viewVerifyUserRegistration() {

--- a/src/js/utils/element-factory.js
+++ b/src/js/utils/element-factory.js
@@ -38,12 +38,13 @@ export const getForm = (action, method) => {
   });
 };
 
-export const getInput = (type, label) => {
+export const getInput = (type, label, value="") => {
   const name = label.split(" ").join("_");
   return $("<input />", {
     class: "card input-field w-input",
     type: type,
     name: name,
+    value: value,
     id: `my-muni-${label}`,
   });
 };

--- a/src/js/utils/element-factory.js
+++ b/src/js/utils/element-factory.js
@@ -38,7 +38,7 @@ export const getForm = (action, method) => {
   });
 };
 
-export const getInput = (type, label, value="") => {
+export const getInput = (type, label, value = "") => {
   const name = label.split(" ").join("_");
   return $("<input />", {
     class: "card input-field w-input",


### PR DESCRIPTION
Highlights:
- Adds optional `value` default argument to `getInput` to allow populating input fields on creation (specifically used to populate hidden fields in this PR)
- Adds `user_id`, `signature` and `timestamp` as hidden fields to the reset password form
- Renames existing `Reset Password` component, view and route to `Forgot Password` 
- Adds new `Reset Password` component, view and route to allow user to submit their new password

Questions:
- Is it fine for me to add the `link-text.form-submit` css class to `src.css.citizen-engagement-app.webflow.css`? I am only concerned because it has `webflow` in the name, so I am not sure if this will be overridden during an import?
