### PR TITLE
Show helpful fail message for login failure and allow retry

### DIFF
--- a/src/js/components/account/login.js
+++ b/src/js/components/account/login.js
@@ -74,9 +74,12 @@ export class Login {
         }
       })
       .fail((jqXHR, textStatus) => {
-        // $form.hide();
-        const errorMessage = jqXHR.responseJSON.detail;
-        window.console.log(jqXHR.responseJSON);
+        $form[0].reset();
+
+        let errorMessage = "Error while communicating with the server";
+        if (jqXHR.status === 400) {
+          errorMessage = jqXHR.responseJSON.detail;
+        }
         $fail.empty().append(errorMessage).show();
         console.error(jqXHR, textStatus);
       });

--- a/src/js/components/account/login.js
+++ b/src/js/components/account/login.js
@@ -38,9 +38,9 @@ export class Login {
 
     $form.append($submitButton);
 
-    $loginFormContainer.append($form);
     $loginFormContainer.append($successTemplate);
     $loginFormContainer.append($failTemplate);
+    $loginFormContainer.append($form);
 
     $form.submit((event) => {
       event.preventDefault();
@@ -74,11 +74,10 @@ export class Login {
         }
       })
       .fail((jqXHR, textStatus) => {
-        $form.hide();
-        $fail
-          .empty()
-          .append("Error while communicating with the server")
-          .show();
+        // $form.hide();
+        const errorMessage = jqXHR.responseJSON.detail;
+        window.console.log(jqXHR.responseJSON);
+        $fail.empty().append(errorMessage).show();
         console.error(jqXHR, textStatus);
       });
   }

--- a/src/js/components/account/login.js
+++ b/src/js/components/account/login.js
@@ -68,6 +68,7 @@ export class Login {
           setMenuState();
 
           $form.hide();
+          $fail.hide();
           $success.empty().append("You are now logged in").show();
 
           window.location = "/services/";


### PR DESCRIPTION
If the response status is `400` we show the error message in the `detail` key. 

![login-invalid-ce](https://user-images.githubusercontent.com/7869992/106513533-c9baa580-64db-11eb-9602-77045a729f49.png)

If it is a non `400` error, we show the default error message: `Error while communicating with the server`

![error-non-400](https://user-images.githubusercontent.com/7869992/106514033-6a10ca00-64dc-11eb-814c-e2488f6209cc.png)

In both cases, the form is cleared.

The error message has been moved to the top (from the bottom) of the form for visibility.