### PR TITLE
fix: use image--rounded for profile images

### DIFF
--- a/src/js/components/pages.js
+++ b/src/js/components/pages.js
@@ -78,27 +78,19 @@ class Page {
     ];
   }
 
-  /**
-   *
-   * @param {String} [imgType] - One of profile or thumbnail - [default: thumbnail]
-   */
-  renderProfileImage(imgType) {
+  renderProfileImage() {
     const elements = [];
 
     if (this.profileImage) {
       const imageUrl = this.profileImage.meta.download_url;
       const imageAlt = this.profileImage.title;
 
-      if (imgType === "profile") {
-        const $profileImage = $("<img />", {
-          src: imageUrl,
-          alt: imageAlt,
-          class: "image image--rounded",
-        });
-        elements.push($profileImage);
-      } else {
-        elements.push($(`<img src="${imageUrl}" alt="${imageAlt}" />`));
-      }
+      const $profileImage = $(".components .image.image--rounded").clone();
+      $profileImage.attr({
+        src: imageUrl,
+        alt: imageAlt,
+      });
+      elements.push($profileImage);
     }
     return elements;
   }
@@ -217,7 +209,7 @@ export class PersonPage extends Page {
   render() {
     const pageContent = [
       new Breadcrumbs(this.breadcrumbItems).render(),
-      ...this.renderProfileImage("profile"),
+      ...this.renderProfileImage(),
     ];
 
     if (this.role) {

--- a/src/js/components/pages.js
+++ b/src/js/components/pages.js
@@ -78,12 +78,27 @@ class Page {
     ];
   }
 
-  renderProfileImage() {
+  /**
+   *
+   * @param {String} [imgType] - One of profile or thumbnail - [default: thumbnail]
+   */
+  renderProfileImage(imgType) {
     const elements = [];
+
     if (this.profileImage) {
       const imageUrl = this.profileImage.meta.download_url;
       const imageAlt = this.profileImage.title;
-      elements.push($(`<img src="${imageUrl}" alt="${imageAlt}"></img>`));
+
+      if (imgType === "profile") {
+        const $profileImage = $("<img />", {
+          src: imageUrl,
+          alt: imageAlt,
+          class: "image image--rounded",
+        });
+        elements.push($profileImage);
+      } else {
+        elements.push($(`<img src="${imageUrl}" alt="${imageAlt}" />`));
+      }
     }
     return elements;
   }
@@ -202,7 +217,7 @@ export class PersonPage extends Page {
   render() {
     const pageContent = [
       new Breadcrumbs(this.breadcrumbItems).render(),
-      ...this.renderProfileImage(),
+      ...this.renderProfileImage("profile"),
     ];
 
     if (this.role) {


### PR DESCRIPTION
On an individuals profile, use the `image image--rounded` classes for the profile image

![Screenshot 2021-02-15 at 11 10 14](https://user-images.githubusercontent.com/10350960/107926459-69694080-6f7e-11eb-8bb7-883658c845cd.png)
