### PR TITLE
fix: fix name attribute for email input field - service requests

### DIFF
--- a/src/js/components/service-requests/submit-service-request.js
+++ b/src/js/components/service-requests/submit-service-request.js
@@ -120,7 +120,7 @@ export class SubmitServiceRequest {
     const $emailLabel = getLabel("Email address");
     const $emailInput = $formInputTmpl.clone().attr({
       id: "email-address",
-      name: "email_address",
+      name: "user_email_address",
       placeholder: "",
       type: "email",
     });


### PR DESCRIPTION
The email input field's `name` attribute should be `user_email_address`
