### PR TITLE
fix: rich text block expand/collapse

### DIFF
--- a/src/js/components/rich-text.js
+++ b/src/js/components/rich-text.js
@@ -11,6 +11,7 @@ export class ExpandableRichText {
     this.$openButton.on(
       "click",
       (() => {
+        Webflow.require("ix2").init();
         this.$contentContainer.addClass("expanded");
         this.$gradientContainer.addClass("expanded");
         this.$openButton.addClass("expanded");


### PR DESCRIPTION
At some point the expand and collapse functionality of the rich text block stopped working.
Adding `Webflow.require("ix2").init();` to the open button click event resolves the problem.
