### PR TITLE
fix: update social share links on navigate

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -420,6 +420,9 @@ class Router {
           pageType: route.viewType,
         });
         route.view(match.groups, path);
+        // because we client side navigate, we need
+        // to update the links on each navigation
+        setShareMenuLinks();
         return;
       }
     }


### PR DESCRIPTION
Because we client side navigate, the function `setShareMenuLinks` was only called the very first time.
To ensure it always uses the latest URL we need to call the function after each navigation event.
