### PR TITLE
fix: add app support menu item

### DIFF
--- a/src/js/utils/menu.js
+++ b/src/js/utils/menu.js
@@ -56,7 +56,7 @@ export const setMenuState = () => {
     "Settings"
   );
   const $supportLink = getAnchorElement(
-    "mailto:cape-agulhas-app@openup.org.za?subject=Cape%20Agulhas%20App%20Support%20Request&body=Support%20request%20URL:",
+    "mailto:cape-agulhas-app@openup.org.za?subject=Cape%20Agulhas%20App%20Support%20Request&body=Page: ",
     "nav-link w-inline-block",
     "App support and feedback"
   );

--- a/src/js/utils/menu.js
+++ b/src/js/utils/menu.js
@@ -55,6 +55,11 @@ export const setMenuState = () => {
     "nav-link w-inline-block",
     "Settings"
   );
+  const $supportLink = getAnchorElement(
+    "mailto:cape-agulhas-app@openup.org.za?subject=Cape%20Agulhas%20App%20Support%20Request&body=Support%20request%20URL:",
+    "nav-link w-inline-block",
+    "App support and feedback"
+  );
 
   $navMenu.find(".nav-link").remove();
   $navMenu.append([
@@ -63,6 +68,7 @@ export const setMenuState = () => {
     $registerLink,
     $settingsLink,
     $serviceRequestsIndex,
+    $supportLink,
   ]);
   Webflow.require("ix2").init();
 
@@ -83,4 +89,9 @@ export const setMenuState = () => {
     $serviceRequestsIndex.show();
     $registerLink.show();
   }
+
+  $supportLink.on("click", () => {
+    const currentHref = $supportLink.attr("href");
+    $supportLink.attr("href", currentHref + document.location.href);
+  });
 };


### PR DESCRIPTION
Add app support link to the menu. The link will open the default mail app, set the subject, and set the current URL in the body of the email.

![Screenshot 2021-05-18 at 15 59 33](https://user-images.githubusercontent.com/10350960/118665285-79e5bd00-b7f2-11eb-8506-07f8468fc9d6.png)

