### PR TITLE
Featured notices and news

### DIFF
--- a/src/js/components/pages.js
+++ b/src/js/components/pages.js
@@ -366,8 +366,16 @@ export class NoticeIndexPage {
     this.childPages = content.child_pages;
   }
 
-  renderChildPageLinks() {
-    const childPageLinks = this.childPages.map((page) => {
+  renderChildPageLinks(is_featured = null) {
+    let filteredLinks = this.childPages;
+
+    if (is_featured !== null) {
+      filteredLinks = this.childPages.filter(
+        (page) => page.featured === is_featured
+      );
+    }
+
+    const childPageLinks = filteredLinks.map((page) => {
       const props = {
         title: page.title,
         url: page.url,
@@ -384,10 +392,31 @@ export class NoticeIndexPage {
     }
   }
 
+  renderFeaturedNotices() {
+    const featuredNotices = this.renderChildPageLinks(true);
+
+    if (featuredNotices.length > 0) {
+      return [
+        new SectionHeading("Featured Notices").render(),
+        ...featuredNotices,
+      ];
+    } else {
+      return [];
+    }
+  }
+
+  renderAllNotices() {
+    return [
+      new SectionHeading("All Notices").render(),
+      ...this.renderChildPageLinks(),
+    ];
+  }
+
   render() {
     return [
       new Breadcrumbs(this.breadcrumbItems).render(),
-      ...this.renderChildPageLinks(),
+      ...this.renderFeaturedNotices(),
+      ...this.renderAllNotices(),
     ];
   }
 }

--- a/src/js/components/pages.js
+++ b/src/js/components/pages.js
@@ -362,24 +362,25 @@ export class ServicePointPage extends Service {}
 
 export class NoticeIndexPage {
   constructor(content) {
+    this.pageNamePlural = "Notices"
     this.breadcrumbItems = getBreadcrumbsWithLabel(content.ancestor_pages);
     this.childPages = content.child_pages;
   }
 
   renderChildPageLinks(is_featured = null) {
-    let filteredLinks = this.childPages;
+    let filteredPages = this.childPages;
 
     if (is_featured !== null) {
-      filteredLinks = this.childPages.filter(
+      filteredPages = this.childPages.filter(
         (page) => page.featured === is_featured
       );
     }
 
-    const childPageLinks = filteredLinks.map((page) => {
+    const childPageLinks = filteredPages.map((page) => {
       const props = {
         title: page.title,
         url: page.url,
-        subtitle: "",
+        subtitle: page.subtitle,
       };
 
       return new LinkBlock(props);
@@ -392,12 +393,12 @@ export class NoticeIndexPage {
     }
   }
 
-  renderFeaturedNotices() {
+  renderFeatured() {
     const featuredNotices = this.renderChildPageLinks(true);
 
     if (featuredNotices.length > 0) {
       return [
-        new SectionHeading("Featured Notices").render(),
+        new SectionHeading(`Featured ${this.pageNamePlural}`).render(),
         ...featuredNotices,
       ];
     } else {
@@ -405,9 +406,9 @@ export class NoticeIndexPage {
     }
   }
 
-  renderAllNotices() {
+  renderAll() {
     return [
-      new SectionHeading("All Notices").render(),
+      new SectionHeading(`All ${this.pageNamePlural}`).render(),
       ...this.renderChildPageLinks(),
     ];
   }
@@ -415,8 +416,8 @@ export class NoticeIndexPage {
   render() {
     return [
       new Breadcrumbs(this.breadcrumbItems).render(),
-      ...this.renderFeaturedNotices(),
-      ...this.renderAllNotices(),
+      ...this.renderFeatured(),
+      ...this.renderAll(),
     ];
   }
 }
@@ -438,7 +439,12 @@ export class NoticePage {
   }
 }
 
-export class NewsIndexPage extends NoticeIndexPage {}
+export class NewsIndexPage extends NoticeIndexPage {
+  constructor(content) {
+    super(content);
+    this.pageNamePlural = "News"
+  }
+}
 
 export class NewsPage extends NoticePage {}
 


### PR DESCRIPTION
https://github.com/OpenUpSA/muni-portal-backend/pull/83

Note that I have not included:
- the date as in the mockup since there is no link block variation available for this format in the webflow documentation.
- the search bar as this is not explicitly mentioned to be included in the trello card and seems like a feature of its own separate to this task
- a homepage section that shows featured notices / news since there is no mockup for it and @jbothma / adrian have not confirmed if we are to include it yet

## Featured notice with more than 0 featured items
![featured-notices](https://user-images.githubusercontent.com/7869992/120112684-13a85500-c177-11eb-928b-de0109fd4584.png)

## Featured news with more than 0 featured items
![featured-news](https://user-images.githubusercontent.com/7869992/120112688-1acf6300-c177-11eb-8917-5334d216eb7d.png)

## Featured news with 0 featured items
![featured-news-no-featured](https://user-images.githubusercontent.com/7869992/120112696-215dda80-c177-11eb-9ac0-153419c62825.png)
