### PR TITLE
fix: do not send page url

### DIFF
--- a/src/js/components/contact.js
+++ b/src/js/components/contact.js
@@ -33,8 +33,7 @@ export class Contact {
       this.$element = new LinkBlock(props).render();
       this.$element.on("click", () => {
         sendEvent({
-          event: contact.type.label,
-          page: document.location.href,
+          event: `Contact event for: ${contact.type.label}`,
           type: contact.annotation || "contact",
         });
       });

--- a/src/js/components/rich-text.js
+++ b/src/js/components/rich-text.js
@@ -18,7 +18,6 @@ export class ExpandableRichText {
         this.$openButton.addClass("expanded");
         sendEvent({
           event: "rich-text-expand",
-          page: document.location.href,
           type: "rich-text",
         });
       }).bind(this)
@@ -31,7 +30,6 @@ export class ExpandableRichText {
         this.$openButton.removeClass("expanded");
         sendEvent({
           event: "rich-text-collapse",
-          page: document.location.href,
           type: "rich-text",
         });
       }).bind(this)

--- a/src/js/components/service-requests/images.js
+++ b/src/js/components/service-requests/images.js
@@ -98,7 +98,6 @@ function addRemoveImageEventHandler($preview, uploadedFiles, uuid) {
     toggleSubmitImagesButton($("#submit-images"), uploadedFiles);
     sendEvent({
       event: "submit-service-request",
-      page: document.location.href,
       type: "Remove existing image",
     });
   });

--- a/src/js/components/service-requests/service-request-map.js
+++ b/src/js/components/service-requests/service-request-map.js
@@ -93,7 +93,6 @@ export const initMap = () => {
         getLocation(map);
         sendEvent({
           event: "service-request-location-picker",
-          page: document.location.href,
           type: "map-location",
         });
       });

--- a/src/js/components/service-requests/submit-service-request.js
+++ b/src/js/components/service-requests/submit-service-request.js
@@ -293,7 +293,6 @@ export class SubmitServiceRequest {
       );
       sendEvent({
         event: "submit-service-request",
-        page: document.location.href,
         type: "Upload new image",
       });
     }

--- a/src/js/utils/menu.js
+++ b/src/js/utils/menu.js
@@ -122,7 +122,6 @@ export const setMenuState = () => {
 
     sendEvent({
       event: "main-menu-interaction",
-      page: document.location.href,
       type: type,
     });
   });


### PR DESCRIPTION
The URL of the page is already available in GTM, no need to send it again.
