### PR TITLE
fix: only show static map if valid coords

### DIFF
--- a/src/js/components/service-requests/service-request-detail.js
+++ b/src/js/components/service-requests/service-request-detail.js
@@ -148,7 +148,13 @@ export class ServiceRequestDetail {
           );
         }
 
-        if (response.coordinates) {
+        // only show the map if we have coordinates and
+        // we can accurately split the value into an
+        // array with a length of 2
+        if (
+          response.coordinates &&
+          response.coordinates.split(",").length === 2
+        ) {
           const staticMapEvent = new CustomEvent("add-static-map", {
             detail: response.coordinates,
           });

--- a/src/js/components/service-requests/service-request-map.js
+++ b/src/js/components/service-requests/service-request-map.js
@@ -15,11 +15,11 @@ function setSelectedLocation(coordinates) {
   );
 
   if ($coordinatesOutput) {
-    $coordinatesOutput.text(coordinates.join(", "));
+    $coordinatesOutput.text(coordinates.join(","));
   }
 
   if ($coordinatesHiddenField) {
-    $coordinatesHiddenField.val(coordinates.join(", "));
+    $coordinatesHiddenField.val(coordinates.join(","));
   }
 
   if ($removeCoordinatesButton) {


### PR DESCRIPTION
Only show the map if we could accurately split the value returned by the API
